### PR TITLE
Remove tagline white background

### DIFF
--- a/theme/static/css/main.css
+++ b/theme/static/css/main.css
@@ -2,6 +2,10 @@
   background: linear-gradient(to top, #002E82, #005BA3,#76AADB);
 }
 
+p.hero__tagline {
+  color: #FFF;
+}
+
 .hero img {
   height: 200px;
 }

--- a/theme/templates/includes/hero.html
+++ b/theme/templates/includes/hero.html
@@ -5,7 +5,7 @@
         {{page.title}}
       {% else %}
         <img src="{{filename}}theme/images/logo-white.svg" /></h1>
-        <p class="hero__white-background">{{ data.identity.tagline }}</p>
+        <p class="hero__tagline">{{ data.identity.tagline }}</p>
       {% endif %}
   </div>
 </div>


### PR DESCRIPTION
Prevent tagline to look like a search bar. :>

![image](https://user-images.githubusercontent.com/1301085/45753542-7b155500-bc19-11e8-97a9-a26e7bc10206.png)
